### PR TITLE
feat(lint): enhance IO 003 rule and skip some variable checks

### DIFF
--- a/examples/good-example/providers.tf
+++ b/examples/good-example/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = ">=1.70.1"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region     = var.region_name
+  access_key = var.access_key
+  secret_key = var.secret_key
+}

--- a/examples/good-example/variables.tf
+++ b/examples/good-example/variables.tf
@@ -1,5 +1,20 @@
-# Variable definitions
+# Variable definitions for authentication
+variable "region_name" {
+  description = "The region where the ECS instance is located"
+  type        = string
+}
 
+variable "access_key" {
+  description = "The access key of the IAM user"
+  type        = string
+}
+
+variable "secret_key" {
+  description = "The secret key of the IAM user"
+  type        = string
+}
+
+# Variable definitions for resources/data sources
 variable "vpc_name" {
   description = "The name of the VPC"
   type        = string


### PR DESCRIPTION
Skip the definitions of these variable input values:
- All values that input variable name is start with `region`
- `access_key`
- `secret_key`
- `domain_name`