### PR TITLE
fix(lint): make the --exclude-path option work

### DIFF
--- a/.github/scripts/terraform_lint.py
+++ b/.github/scripts/terraform_lint.py
@@ -254,13 +254,26 @@ class TerraformLinter:
 
         # Check exclude paths
         for pattern in self.exclude_paths:
+            # Normalize pattern to handle ./ prefixes consistently
+            normalized_pattern = os.path.normpath(pattern)
+            
             # Handle directory patterns (e.g., "examples" should match "examples/*")
-            if '/' not in pattern and '*' not in pattern:
+            if '/' not in normalized_pattern and '*' not in normalized_pattern:
                 # Simple directory name - check if path starts with this directory
-                if normalized_path.startswith(pattern + '/') or normalized_path.startswith('./' + pattern + '/'):
+                if (normalized_path.startswith(normalized_pattern + '/') or 
+                    normalized_path.startswith('./' + normalized_pattern + '/') or
+                    file_path.startswith(normalized_pattern + '/') or
+                    file_path.startswith('./' + normalized_pattern + '/')):
                     return True
-            # Handle glob patterns
-            elif fnmatch.fnmatch(normalized_path, pattern) or fnmatch.fnmatch(file_path, pattern):
+            # Handle glob patterns and exact paths
+            elif (fnmatch.fnmatch(normalized_path, normalized_pattern) or
+                  fnmatch.fnmatch(file_path, normalized_pattern) or
+                  fnmatch.fnmatch(normalized_path, pattern) or
+                  fnmatch.fnmatch(file_path, pattern) or
+                  normalized_path.startswith(normalized_pattern + '/') or
+                  file_path.startswith(normalized_pattern + '/') or
+                  normalized_path.startswith(pattern + '/') or
+                  file_path.startswith(pattern + '/')):
                 return True
 
         return False

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -141,11 +141,17 @@ hcbp-lint --categories "ST,IO,DC,SC"
 ### 3. Advanced Filtering
 
 ```bash
-# Exclude specific paths
+# Exclude specific paths - Multiple patterns supported
 hcbp-lint --exclude-paths "test/*,examples/*,*.backup"
 
-# Include only specific paths
+# Directory exclusion (all formats work)
+hcbp-lint --exclude-paths "bad-examples"          # Directory name
+hcbp-lint --exclude-paths "./bad-examples"        # Relative path with ./
+hcbp-lint --exclude-paths "bad-examples/*"        # Wildcard pattern
+
+# Include only specific paths - Multiple patterns supported
 hcbp-lint --include-paths "modules/*,environments/prod/*"
+# The include path format is the same as --exclude-paths
 
 # Ignore specific rules
 hcbp-lint --ignore-rules "ST.001,ST.003"
@@ -153,6 +159,12 @@ hcbp-lint --ignore-rules "ST.001,ST.003"
 # JSON output format
 hcbp-lint --report-format json
 ```
+
+**Path Filtering Tips:**
+- Use commas to separate multiple patterns: `"pattern1,pattern2,pattern3"`
+- Directory names automatically match subdirectories: `"examples"` excludes `examples/*`
+- Glob patterns are supported: `"test/*"`, `"*.backup"`, `"**/*.tmp"`
+- Both relative (`"./examples"`) and simple (`"examples"`) formats work
 
 ### 4. Git Integration
 


### PR DESCRIPTION
## Resolve exclude-paths parameter not working with "./directory" format

### Problem
The `--exclude-paths` parameter was not correctly excluding directories when using relative path format like `"./bad-examples"`. Users reported that running:
```bash
hcbp-lint --directory ./examples --exclude-paths "./bad-examples"
```
was not excluding the `bad-examples` directory as expected.

### Root Cause
The `should_exclude_path` method in `terraform_lint.py` was not normalizing exclude patterns before comparison. When a pattern like `"./bad-examples"` was provided, it was only checking for exact matches with `"./bad-examples/"` prefix, but the actual file paths were normalized to `"bad-examples/..."` format, causing the exclusion to fail.

### Solution
- **Enhanced pattern normalization**: Added `os.path.normpath()` processing for exclude patterns to handle `./` prefixes consistently
- **Improved path matching logic**: Extended the path matching to check both normalized and original patterns against both normalized and original file paths
- **Better directory pattern handling**: Enhanced detection of simple directory names vs. glob patterns

### Changes Made
1. **Modified `should_exclude_path` method** in `.github/scripts/terraform_lint.py`:
   - Added pattern normalization using `os.path.normpath(pattern)`
   - Enhanced directory pattern matching to handle multiple format variations
   - Improved glob pattern matching with comprehensive path comparisons

2. **Updated documentation** in `QUICKSTART.md`:
   - Added clear examples of different exclude-paths formats
   - Included path filtering tips explaining supported patterns
   - Clarified that both relative and simple formats work

### Testing Results
All exclude-paths formats now work correctly:
- ✅ `"./bad-examples"` (relative path with ./)
- ✅ `"bad-examples"` (simple directory name)  
- ✅ `"bad-examples/*"` (wildcard pattern)

**Before fix**: Found 17 files (bad-examples not excluded)
**After fix**: Found 5 files (bad-examples correctly excluded)

### Backward Compatibility
- All existing exclude-paths patterns continue to work
- No breaking changes to API or command-line interface
- Enhanced functionality is additive only

### Documentation Updates
- Added comprehensive path filtering examples
- Included tips for different pattern formats
- Clarified multi-pattern usage with commas