### PR TITLE
feat(rule): ST.009 rule allow any location about authentication parameters

### DIFF
--- a/rules/st_rules/README.md
+++ b/rules/st_rules/README.md
@@ -273,6 +273,8 @@ the longest parameter name.
 **Validation Criteria**:
 - Variable definition order in variables.tf must match usage order in main.tf
 - Cross-file analysis for maintaining logical organization
+- Provider-related variables (access_key, secret_key, region_name) are excluded from ordering validation
+- Excludes authentication and region configuration variables to avoid interference with business logic ordering
 
 ### ST.010 - Resource, Data Source, Variable, and Output Quote Check
 


### PR DESCRIPTION
ST.009 rules now support excluding authentication and region configuration parameters such as `access_key`, `secret_key`, and `region_name` from variable sorting.

## Functional Description

### Excluded Variables
- `access_key` - IAM user access key
- `secret_key` - IAM user secret key
- `region_name` - Region name

### Exclusion Reason
1. **Authentication Parameter Independence**: These variables are used for cloud provider authentication and region configuration and are not related to the ordering of business logic variables.
2. **Configuration Flexibility**: These variables can be defined anywhere in `variables.tf` without affecting ordering validation.
3. **Best Practice**: Conforms to common authentication configuration patterns in Terraform projects.

## Implementation Details

### Modified Functions

#### `_extract_variable_usage_order()`
- Excludes provider variables when extracting variable usage order.
- Returns only the usage order of business logic variables.

#### `_extract_variable_definition_order()`
- Excludes provider variables when extracting variable definition order.
- Returns only the definition order of business logic variables.

### Exclusion Logic
```python
def _should_exclude_variable(var_name: str) -> bool:
""Check if a variable should be excluded from ordering validation."""
if var_name in ['access_key', 'secret_key', 'region_name']:
return True
return False
```

## Usage Example

### Valid Configuration

**main.tf** (Variable usage order: vpc_name, vpc_cidr, subnet_name)
```hcl
resource "huaweicloud_vpc" "test" {
name = var.vpc_name
cidr = var.vpc_cidr
}

resource "huaweicloud_vpc_subnet" "test" {
name = var.subnet_name
# ... other configuration
}
```

**variables.tf** (provider Variables can be placed anywhere)
```hcl
# Provider variables (excluded from ordering validation)
variable "region_name" {
description = "The region where resources are located"
type = string
}

variable "access_key" {
description = "The access key of the IAM user"
type = string
}

# Business logic variables (defined in order of use)
variable "vpc_name" {
description = "The name of the VPC"
type = string
}

variable "vpc_cidr" {
description = "The CIDR block for the VPC"
type = string
default = "192.168.0.0/16"
}

variable "subnet_name" {
description = "The name of the subnet"
type = string
}

variable "secret_key" {
description = "The secret key of the IAM user"
type = string
}
```

## Test Verification

Run the test script to verify functionality:
```bash
python3 test_st009_provider_variables.py
```

Expected Output:
```
Usage order (excluding provider variables): ['vpc_name', 'vpc_cidr', 'subnet_name']
Definition order (excluding provider variables): ['vpc_name', 'vpc_cidr', 'subnet_name']
✅ access_key correctly excluded from usage order
✅ secret_key correctly excluded from usage order
✅ region_name correctly excluded from usage order
🎉 Test completed successfully!
```

## Backward Compatibility

- Existing code does not require modification
- All existing ST.009 rule checks continue to work correctly
- Only the exclusion of provider variables has been added

## Configuration Options

Added new configuration options to the rule description:
```python
"configuration": {
"check_usage_order": True,

"require_main_tf": True,
"ignore_unused_variables": False,
"excluded_provider_variables": ["access_key", "secret_key", "region_name"]
}
```

## Related Rules

- **IO.003**: Also exclude provider variables for consistency
- **IO.009**: Exclude provider variables from the unused variable check
