### PR TITLE
feat(rule): supports new rule ST.013 to check folder name

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -56,6 +56,7 @@ The tool implements a modular rule system organized into four distinct categorie
 - **ST.010**: Resource, data source, variable, and output quote check (double quotes around names)
 - **ST.011**: Trailing whitespace check (no trailing spaces or tabs at line ends)
 - **ST.012**: File header and footer whitespace check (no empty lines before first non-empty line, exactly one empty line after last non-empty line)
+- **ST.013**: Directory naming convention check (validates directory names contain only letters, numbers, and hyphens, and start/end with letters)
 
 **Implementation Pattern**:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A comprehensive linting tool for Terraform scripts with advanced rule management
 
 ## Features
 
-- **Multi-Category Rules**: 23 rules across ST (Style/Format), IO (Input/Output), DC (Documentation/Comments), and SC (Security Code) categories
+- **Multi-Category Rules**: 24 rules across ST (Style/Format), IO (Input/Output), DC (Documentation/Comments), and SC (Security Code) categories
 - **Comment Control**: Enable/disable specific rules using inline comments
 - **Flexible Configuration**: Path filtering, rule exclusion, and performance monitoring
 - **GitHub Actions Integration**: Seamless CI/CD integration with artifact support
@@ -198,7 +198,7 @@ jobs:
 
 ## Rule Categories
 
-### ST (Style/Format) Rules - 12 Rules
+### ST (Style/Format) Rules - 13 Rules
 - **ST.001**: Resource and data source naming convention check
 - **ST.002**: Variable default value requirement for data sources
 - **ST.003**: Parameter alignment with equals signs
@@ -211,6 +211,7 @@ jobs:
 - **ST.010**: Quote usage consistency check
 - **ST.011**: Trailing whitespace detection
 - **ST.012**: File header and footer whitespace check
+- **ST.013**: Directory naming convention check
 
 ### IO (Input/Output) Rules - 9 Rules
 - **IO.001**: Variable definition file organization

--- a/rules/README.md
+++ b/rules/README.md
@@ -26,6 +26,8 @@ rules/
 │   ├── rule_001.py             # ST.001 - Naming convention check
 |   ├── ...
 │   ├── rule_011.py             # ST.011 - Trailing whitespace check
+│   ├── rule_012.py             # ST.012 - File header and footer whitespace check
+│   ├── rule_013.py             # ST.013 - Directory naming convention check
 │   └── [future rule modules]   # Additional ST rules as separate modules
 ├── dc_rules/                   # DC rules modular package
 │   ├── __init__.py             # Package initialization
@@ -96,6 +98,7 @@ Each rule package follows a consistent design pattern:
 | ST.010 | Quote Usage | Double quotes around resource, data source, variable, and output names | ✅ Modular |
 | ST.011 | Trailing Whitespace | No trailing spaces or tabs at line ends | ✅ Modular |
 | ST.012 | File Header and Footer Whitespace | Files should not have empty lines before first non-empty line and should have exactly one empty line after last non-empty line | ✅ Modular |
+| ST.013 | Directory Naming Convention | Validates directory names contain only letters, numbers, and hyphens, and start/end with letters | ✅ Modular |
 
 ### DC (Documentation/Comments) Rules
 

--- a/rules/st_rules/README.md
+++ b/rules/st_rules/README.md
@@ -22,7 +22,8 @@ st_rules/
 ├── rule_009.py   # ST.009 - Variable definition order check
 ├── rule_010.py   # ST.010 - Resource, data source, variable, and output quote check
 ├── rule_011.py   # ST.011 - Trailing whitespace check
-└── rule_012.py   # ST.012 - File header and footer whitespace check
+├── rule_012.py   # ST.012 - File header and footer whitespace check
+└── rule_013.py   # ST.013 - Directory naming convention check
 ```
 
 ## 🎯 Available Rules
@@ -41,6 +42,7 @@ st_rules/
 | ST.010 | Resource, data source, variable, and output quote check | Ensures double quotes around resource/data source names | `rule_010.py` |
 | ST.011 | Trailing whitespace check | Removes trailing spaces and tabs from line endings | `rule_011.py` |
 | ST.012 | File header and footer whitespace check | Ensures no extra whitespace at the beginning or end of the file | `rule_012.py` |
+| ST.013 | Directory naming convention check | Validates directory names contain only letters, numbers, and hyphens, and start/end with letters | `rule_013.py` |
 
 ## 🚀 Usage
 
@@ -301,6 +303,21 @@ the longest parameter name.
 **Validation Criteria**:
 - No leading or trailing whitespace at the beginning of the file
 - No leading or trailing whitespace at the end of the file
+
+### ST.013 - Directory Naming Convention Check
+
+**Purpose**: Validates that all directory names follow proper naming conventions.
+
+**Validation Criteria**:
+- Directory names must contain only letters, numbers, and hyphens
+- Directory names must start and end with a letter
+- No consecutive hyphens allowed
+- Recursively checks all subdirectories at any depth
+- Automatically skips hidden directories and system directories
+
+**Examples**:
+- Valid: `my-project`, `terraform-modules`, `test-env-1`, `data-processing`
+- Invalid: `_private-dir` (starts with underscore), `my-project-` (ends with hyphen), `123-project` (starts with number)
 
 ## 🔄 Backward Compatibility
 

--- a/rules/st_rules/reference.py
+++ b/rules/st_rules/reference.py
@@ -31,6 +31,7 @@ from .rule_009 import check_st009_variable_order, get_rule_description as get_st
 from .rule_010 import check_st010_quote_usage, get_rule_description as get_st010_description
 from .rule_011 import check_st011_trailing_whitespace, get_rule_description as get_st011_description
 from .rule_012 import check_st012_file_whitespace, get_rule_description as get_st012_description
+from .rule_013 import check_st013_directory_naming, get_rule_description as get_st013_description
 
 
 class STRules:
@@ -124,6 +125,12 @@ class STRules:
                 "check_function": check_st012_file_whitespace,
                 "description_function": get_st012_description,
                 "name": "File header and footer whitespace check",
+                "status": "modular"
+            },
+            "ST.013": {
+                "check_function": check_st013_directory_naming,
+                "description_function": get_st013_description,
+                "name": "Directory naming convention check",
                 "status": "modular"
             }
         }

--- a/rules/st_rules/rule_013.py
+++ b/rules/st_rules/rule_013.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+ST.013 - Directory Naming Convention Check
+
+This module implements the ST.013 rule which validates that all directory names
+in the current directory and all subdirectories follow proper naming conventions.
+
+Rule Specification:
+- Directory names must contain only letters, numbers, and hyphens
+- Directory names must start and end with a letter
+- This applies to all directories at any depth from the current directory
+- Helps maintain consistency in project structure and naming
+
+Examples:
+    Valid directory names:
+        - my-project
+        - terraform-modules
+        - test-env-1
+        - data-processing
+        - api-gateway
+
+    Invalid directory names:
+        - _private-dir (starts with underscore)
+        - my-project- (ends with hyphen)
+        - 123-project (starts with number)
+        - my_project (contains underscore)
+        - my.project (contains dot)
+        - my project (contains space)
+
+Author: Lance
+License: Apache 2.0
+"""
+
+import os
+import re
+from typing import Callable, List, Optional, Set
+from pathlib import Path
+
+
+def check_st013_directory_naming(file_path: str, content: str, log_error_func: Callable[[str, str, str, Optional[int]], None]) -> None:
+    """
+    Check if all directory names follow proper naming conventions.
+    
+    This function validates that all directory names in the current directory
+    and all subdirectories follow the naming convention of:
+    - Containing only letters, numbers, and hyphens
+    - Starting and ending with a letter
+    
+    Args:
+        file_path (str): Path to the file being checked (used to determine base directory)
+        content (str): File content (not used for this rule)
+        log_error_func (Callable): Function to log errors with signature (file_path, rule_id, message, line_num)
+    """
+    # Get the base directory from the file path
+    base_dir = os.path.dirname(os.path.abspath(file_path))
+    
+    # Find all directories recursively
+    directories = _find_all_directories(base_dir)
+    
+    # Check each directory name
+    for dir_path in directories:
+        dir_name = os.path.basename(dir_path)
+        
+        # Skip hidden directories and common system directories
+        if _should_skip_directory(dir_name):
+            continue
+            
+        # Check if directory name follows naming convention
+        if not _is_valid_directory_name(dir_name):
+            error_msg = f"Directory name '{dir_name}' does not follow naming convention. Must contain only letters, numbers, and hyphens, and start/end with a letter."
+            log_error_func(dir_path, "ST.013", error_msg, None)
+
+
+def _find_all_directories(base_dir: str) -> List[str]:
+    """
+    Find all directories recursively starting from the base directory.
+    
+    Args:
+        base_dir (str): Base directory to start searching from
+        
+    Returns:
+        List[str]: List of all directory paths found
+    """
+    directories = []
+    
+    try:
+        for root, dirs, files in os.walk(base_dir):
+            for dir_name in dirs:
+                dir_path = os.path.join(root, dir_name)
+                directories.append(dir_path)
+    except (OSError, PermissionError) as e:
+        # If we can't access a directory, skip it silently
+        pass
+    
+    return directories
+
+
+def _should_skip_directory(dir_name: str) -> bool:
+    """
+    Check if a directory should be skipped from naming convention checks.
+    
+    Args:
+        dir_name (str): Directory name to check
+        
+    Returns:
+        bool: True if directory should be skipped, False otherwise
+    """
+    # Skip hidden directories
+    if dir_name.startswith('.'):
+        return True
+    
+    # Skip common system directories
+    skip_dirs = {
+        '__pycache__',
+        'node_modules',
+        '.git',
+        '.svn',
+        '.hg',
+        'venv',
+        'env',
+        '.venv',
+        '.env',
+        'build',
+        'dist',
+        'target',
+        'bin',
+        'obj',
+        '.vs',
+        '.vscode',
+        '.idea',
+        '.settings',
+        'coverage',
+        '.coverage',
+        'htmlcov',
+        '.pytest_cache',
+        '.tox',
+        '.mypy_cache',
+        '.ruff_cache'
+    }
+    
+    return dir_name.lower() in skip_dirs
+
+
+def _is_valid_directory_name(dir_name: str) -> bool:
+    """
+    Check if a directory name follows the naming convention.
+    
+    Args:
+        dir_name (str): Directory name to validate
+        
+    Returns:
+        bool: True if directory name is valid, False otherwise
+    """
+    # Check if directory name is empty
+    if not dir_name:
+        return False
+    
+    # Check if directory name contains only letters, numbers, and hyphens
+    if not re.match(r'^[a-zA-Z0-9-]+$', dir_name):
+        return False
+    
+    # Check if directory name starts and ends with a letter
+    if not re.match(r'^[a-zA-Z].*[a-zA-Z]$', dir_name):
+        return False
+    
+    # Check for consecutive hyphens (not allowed)
+    if '--' in dir_name:
+        return False
+    
+    return True
+
+
+def get_rule_description() -> dict:
+    """
+    Get the rule description for ST.013.
+    
+    Returns:
+        dict: Rule description containing metadata and details
+    """
+    return {
+        "rule_id": "ST.013",
+        "title": "Directory Naming Convention Check",
+        "category": "Style/Format",
+        "severity": "warning",
+        "description": "Validates that all directory names follow proper naming conventions",
+        "rationale": "Ensures consistent directory naming across the project structure",
+        "scope": ["directory_naming", "project_structure", "naming_conventions"],
+        "implementation": "modular",
+        "version": "1.0.0",
+        "naming_pattern": {
+            "allowed_characters": "letters (a-z, A-Z), numbers (0-9), hyphens (-)",
+            "start_character": "must be a letter",
+            "end_character": "must be a letter",
+            "consecutive_hyphens": "not allowed"
+        },
+        "examples": {
+            "valid": [
+                "my-project",
+                "terraform-modules", 
+                "test-env-1",
+                "data-processing",
+                "api-gateway",
+                "user-management",
+                "config-files"
+            ],
+            "invalid": [
+                "_private-dir (starts with underscore)",
+                "my-project- (ends with hyphen)",
+                "123-project (starts with number)",
+                "my_project (contains underscore)",
+                "my.project (contains dot)",
+                "my project (contains space)",
+                "my--project (consecutive hyphens)"
+            ]
+        },
+        "fix_suggestions": [
+            "Use only letters, numbers, and hyphens in directory names",
+            "Ensure directory names start and end with a letter",
+            "Avoid consecutive hyphens in directory names",
+            "Use kebab-case naming convention (lowercase with hyphens)",
+            "Make directory names descriptive and meaningful"
+        ],
+        "excluded_directories": [
+            "Hidden directories (starting with .)",
+            "System directories (__pycache__, node_modules, .git, etc.)",
+            "Build and cache directories (build, dist, target, etc.)",
+            "IDE and editor directories (.vscode, .idea, .settings, etc.)"
+        ],
+        "recursive_check": True,
+        "max_depth": "unlimited"
+    }

--- a/test_st013.py
+++ b/test_st013.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+测试ST.013规则 - 目录命名规范检查
+"""
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'rules'))
+
+from st_rules.rule_013 import check_st013_directory_naming
+
+def mock_log_error(file_path, rule_id, message, line_num):
+    """模拟错误日志函数"""
+    print(f"[{rule_id}] {file_path}:{line_num} - {message}")
+
+def test_st013_rule():
+    """测试ST.013规则"""
+    print("测试ST.013规则 - 目录命名规范检查")
+    print("="*60)
+    
+    # 创建一个测试文件
+    test_file = 'test-dirs/test.tf'
+    with open(test_file, 'w') as f:
+        f.write('resource "huaweicloud_vpc" "test" {\n  name = "test"\n}')
+    
+    print("测试文件内容:")
+    with open(test_file, 'r') as f:
+        print(f.read())
+    
+    print("\n运行ST.013规则检查:")
+    print("-" * 40)
+    
+    # 运行规则检查
+    check_st013_directory_naming(test_file, "", mock_log_error)
+    
+    print("\n" + "="*60)
+    print("测试完成!")
+
+if __name__ == "__main__":
+    test_st013_rule()

--- a/test_st013_comment_control.py
+++ b/test_st013_comment_control.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+测试ST.013规则的注释控制功能
+"""
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'rules'))
+
+from st_rules.rule_013 import check_st013_directory_naming
+from comment_control import CommentController
+
+def mock_log_error(file_path, rule_id, message, line_num):
+    """模拟错误日志函数"""
+    print(f"[{rule_id}] {file_path}:{line_num} - {message}")
+
+def test_st013_comment_control():
+    """测试ST.013规则的注释控制功能"""
+    print("测试ST.013规则的注释控制功能")
+    print("="*60)
+    
+    # 创建注释控制器
+    comment_controller = CommentController()
+    
+    # 创建测试文件内容（包含注释控制）
+    test_content = '''# ST.013 Disable
+resource "huaweicloud_vpc" "test" {
+  name = "test"
+}
+# ST.013 Enable'''
+    
+    # 创建测试文件
+    test_file = 'test-dirs/test_with_comments.tf'
+    with open(test_file, 'w') as f:
+        f.write(test_content)
+    
+    print("测试文件内容:")
+    print(test_content)
+    print("\n" + "="*60)
+    
+    # 解析注释控制
+    control_states = comment_controller.parse_control_comments(test_content)
+    print("\n解析的注释控制状态:")
+    for line_num, state in control_states.items():
+        print(f"  行 {line_num}: {state.rule_id} {state.control_type}")
+    
+    # 创建受控制的日志函数
+    def controlled_log_func(path: str, rule: str, message: str, line_number: int = None):
+        # 检查规则是否在该行被禁用
+        if line_number is not None and control_states:
+            if not comment_controller.get_rule_state_at_line(rule, line_number, control_states):
+                print(f"  [跳过] {rule} 在第 {line_number} 行被禁用")
+                return  # 跳过日志记录
+        # 调用原始日志函数
+        mock_log_error(path, rule, message, line_number)
+    
+    print("\n运行ST.013规则检查（带注释控制）:")
+    print("-" * 40)
+    check_st013_directory_naming(test_file, test_content, controlled_log_func)
+    
+    print("\n" + "="*60)
+    print("测试完成!")
+
+if __name__ == "__main__":
+    test_st013_comment_control()

--- a/test_st013_manager.py
+++ b/test_st013_manager.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+测试ST.013规则在规则管理器中的集成
+"""
+
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), 'rules'))
+
+from st_rules.reference import STRules
+
+def test_st013_in_manager():
+    """测试ST.013规则在规则管理器中的集成"""
+    print("测试ST.013规则在规则管理器中的集成")
+    print("="*60)
+    
+    # 创建ST规则管理器
+    st_rules = STRules()
+    
+    # 检查规则是否已注册
+    available_rules = st_rules.get_available_rules()
+    print(f"可用规则数量: {len(available_rules)}")
+    print(f"ST.013规则是否已注册: {'ST.013' in available_rules}")
+    
+    # 获取ST.013规则信息
+    rule_info = st_rules.get_rule_info("ST.013")
+    if rule_info:
+        print(f"\nST.013规则信息:")
+        print(f"  规则ID: {rule_info.get('rule_id')}")
+        print(f"  标题: {rule_info.get('title')}")
+        print(f"  类别: {rule_info.get('category')}")
+        print(f"  严重级别: {rule_info.get('severity')}")
+        print(f"  描述: {rule_info.get('description')}")
+        print(f"  实现状态: {rule_info.get('implementation')}")
+        print(f"  版本: {rule_info.get('version')}")
+        
+        # 显示命名模式
+        naming_pattern = rule_info.get('naming_pattern', {})
+        print(f"\n命名模式:")
+        for key, value in naming_pattern.items():
+            print(f"  {key}: {value}")
+        
+        # 显示有效示例
+        examples = rule_info.get('examples', {})
+        if 'valid' in examples:
+            print(f"\n有效示例:")
+            for example in examples['valid'][:5]:  # 只显示前5个
+                print(f"  - {example}")
+        
+        if 'invalid' in examples:
+            print(f"\n无效示例:")
+            for example in examples['invalid'][:5]:  # 只显示前5个
+                print(f"  - {example}")
+    
+    print("\n" + "="*60)
+    print("测试完成!")
+
+if __name__ == "__main__":
+    test_st013_in_manager()


### PR DESCRIPTION
Only letters, digits and hyphens (-) are allowed, and must start with a letter and end with a letter.