### PR TITLE
fix(rule): good examples pass the SC.005 rule

### DIFF
--- a/examples/good-examples/basic/variables.tf
+++ b/examples/good-examples/basic/variables.tf
@@ -7,11 +7,13 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 # Variable definitions for resources/data sources

--- a/examples/good-examples/terraform-versions/import/variables.tf
+++ b/examples/good-examples/terraform-versions/import/variables.tf
@@ -7,11 +7,13 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 # Variable definitions for resources/data sources

--- a/examples/good-examples/terraform-versions/lifecycle/precondition/variables.tf
+++ b/examples/good-examples/terraform-versions/lifecycle/precondition/variables.tf
@@ -7,11 +7,13 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 # Variable definitions for resources/data sources

--- a/examples/good-examples/terraform-versions/nullable/variables.tf
+++ b/examples/good-examples/terraform-versions/nullable/variables.tf
@@ -7,11 +7,13 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 # Variable definitions for resources/data sources

--- a/examples/good-examples/terraform-versions/optional/variables.tf
+++ b/examples/good-examples/terraform-versions/optional/variables.tf
@@ -7,11 +7,13 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 # Variable definitions for resources/data sources

--- a/examples/good-examples/terraform-versions/validation/condition-with-another-var/variables.tf
+++ b/examples/good-examples/terraform-versions/validation/condition-with-another-var/variables.tf
@@ -7,11 +7,13 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 # Variable definitions for resources/data sources

--- a/examples/good-examples/terraform-versions/with-version/variables.tf
+++ b/examples/good-examples/terraform-versions/with-version/variables.tf
@@ -7,9 +7,11 @@ variable "region_name" {
 variable "access_key" {
   description = "The access key of the IAM user"
   type        = string
+  sensitive   = true
 }
 
 variable "secret_key" {
   description = "The secret key of the IAM user"
   type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
Supports `sensitive = true` expressions for the sensitive variables.